### PR TITLE
Improve scripts and add zip ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.env
 node_modules/
 .DS_Store
+*.zip

--- a/setup_bedrock.sh
+++ b/setup_bedrock.sh
@@ -12,8 +12,8 @@ sudo apt install -y unzip wget screen curl
 
 # Set up server directory
 sudo mkdir -p /opt/minecraft-bedrock
-sudo chown $(whoami):$(whoami) /opt/minecraft-bedrock
-cd /opt/minecraft-bedrock
+sudo chown "$(whoami)":"$(whoami)" /opt/minecraft-bedrock
+cd /opt/minecraft-bedrock || exit 1
 
 # Fetch the latest Bedrock server URL
 LATEST_URL=$(curl -s https://www.minecraft.net/en-us/download/server/bedrock | grep -o 'https://minecraft.azureedge.net/bin-linux/bedrock-server-[0-9.]*.zip' | head -1)
@@ -25,13 +25,10 @@ if [[ -z "$LATEST_URL" ]]; then
 fi
 
 echo "Downloading Minecraft Bedrock Server from: $LATEST_URL"
-wget -O bedrock-server.zip "$LATEST_URL"
-
-# Check if the download was successful
-if [[ $? -ne 0 ]]; then
+wget -O bedrock-server.zip "$LATEST_URL" || {
   echo "ERROR: Download failed. Check your internet connection."
   exit 1
-fi
+}
 
 # Check if the file is a valid ZIP archive
 if ! unzip -tq bedrock-server.zip >/dev/null; then

--- a/setup_minecraft.sh
+++ b/setup_minecraft.sh
@@ -18,12 +18,12 @@ fi
 
 # Set up server directory
 sudo mkdir -p /opt/minecraft
-sudo chown $(whoami):$(whoami) /opt/minecraft
-cd /opt/minecraft
+sudo chown "$(whoami)":"$(whoami)" /opt/minecraft
+cd /opt/minecraft || exit 1
 
 # Fetch the latest PaperMC version
 LATEST_VERSION=$(curl -s https://api.papermc.io/v2/projects/paper | jq -r '.versions | last')
-LATEST_BUILD=$(curl -s https://api.papermc.io/v2/projects/paper/versions/$LATEST_VERSION | jq -r '.builds | last')
+LATEST_BUILD=$(curl -s https://api.papermc.io/v2/projects/paper/versions/"$LATEST_VERSION" | jq -r '.builds | last')
 
 # Validate if version and build numbers were retrieved
 if [[ -z "$LATEST_VERSION" || -z "$LATEST_BUILD" ]]; then

--- a/setup_minecraft_lxc.sh
+++ b/setup_minecraft_lxc.sh
@@ -15,11 +15,11 @@ if ! apt install -y openjdk-21-jre-headless; then
 fi
 
 # Create the Minecraft server directory
-mkdir -p /opt/minecraft && cd /opt/minecraft
+mkdir -p /opt/minecraft && cd /opt/minecraft || exit 1
 
 # Fetch the latest PaperMC version
 LATEST_VERSION=$(curl -s https://api.papermc.io/v2/projects/paper | jq -r '.versions | last')
-LATEST_BUILD=$(curl -s https://api.papermc.io/v2/projects/paper/versions/$LATEST_VERSION | jq -r '.builds | last')
+LATEST_BUILD=$(curl -s https://api.papermc.io/v2/projects/paper/versions/"$LATEST_VERSION" | jq -r '.builds | last')
 
 # Validate if the version and build exist
 if [[ -z "$LATEST_VERSION" || -z "$LATEST_BUILD" ]]; then

--- a/update.sh
+++ b/update.sh
@@ -3,7 +3,7 @@
 cd /opt/minecraft || exit 1
 
 LATEST_VERSION=$(curl -s https://api.papermc.io/v2/projects/paper | jq -r '.versions | last')
-LATEST_BUILD=$(curl -s https://api.papermc.io/v2/projects/paper/versions/$LATEST_VERSION | jq -r '.builds | last')
+LATEST_BUILD=$(curl -s https://api.papermc.io/v2/projects/paper/versions/"$LATEST_VERSION" | jq -r '.builds | last')
 
 wget -O server.jar "https://api.papermc.io/v2/projects/paper/versions/$LATEST_VERSION/builds/$LATEST_BUILD/downloads/paper-$LATEST_VERSION-$LATEST_BUILD.jar"
 


### PR DESCRIPTION
## Summary
- ignore zip archives in `.gitignore`
- fix quoting and path handling in shell scripts
- improve error checking in Bedrock setup
- add proper quoting when querying PaperMC in all scripts

## Testing
- `shellcheck setup_minecraft.sh setup_bedrock.sh setup_minecraft_lxc.sh update.sh`

------
https://chatgpt.com/codex/tasks/task_e_688554e3307883338d0d1824c1e71680

## Zusammenfassung von Sourcery

Verbesserung der Robustheit der Minecraft-Einrichtungs- und Update-Skripte durch Hinzufügen korrekter Anführungszeichen, Fehlerbehandlung und Pfadprüfungen sowie Aktualisierung der .gitignore-Datei, um Zip-Archive zu ignorieren

Verbesserungen:
- Hinzufügen des `*.zip`-Musters zur .gitignore-Datei
- Anführungszeichen bei Variablenerweiterungen und Befehlsargumenten in allen Shell-Skripten
- Hinzufügen von Abbruch-bei-Fehler-Prüfungen für `cd`- und `wget`-Befehle
- Vereinheitlichung der Anführungszeichensetzung von URL-Parametern beim Abfragen der PaperMC API in allen Skripten

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve robustness of Minecraft setup and update scripts by adding proper quoting, error handling, and path checks, and update .gitignore to ignore zip archives

Enhancements:
- Add *.zip pattern to .gitignore
- Quote variable expansions and command arguments in all shell scripts
- Add exit-on-failure checks for cd and wget commands
- Unify quoting of URL parameters when querying the PaperMC API in all scripts

</details>