### PR TITLE
Fix shellcheck warnings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/bedrock_helper.sh
+++ b/bedrock_helper.sh
@@ -1,2 +1,3 @@
 #!/bin/bash
+set -euo pipefail
 echo "Manual Bedrock update required. Visit official Mojang page to download."

--- a/setup_bedrock.sh
+++ b/setup_bedrock.sh
@@ -4,7 +4,7 @@
 # Tested on Debian 11/12 and Ubuntu 24.04
 # Author: TimInTech
 
-set -e  # Exit on any error
+set -euo pipefail  # Exit on error, unset variable, or failed pipeline
 
 # Install required dependencies
 sudo apt update && sudo apt upgrade -y

--- a/setup_bedrock.sh
+++ b/setup_bedrock.sh
@@ -12,7 +12,7 @@ sudo apt install -y unzip wget screen curl
 
 # Set up server directory
 sudo mkdir -p /opt/minecraft-bedrock
-sudo chown $(whoami):$(whoami) /opt/minecraft-bedrock
+sudo chown "$(whoami)":"$(whoami)" /opt/minecraft-bedrock
 cd /opt/minecraft-bedrock
 
 # Fetch the latest Bedrock server URL
@@ -25,10 +25,7 @@ if [[ -z "$LATEST_URL" ]]; then
 fi
 
 echo "Downloading Minecraft Bedrock Server from: $LATEST_URL"
-wget -O bedrock-server.zip "$LATEST_URL"
-
-# Check if the download was successful
-if [[ $? -ne 0 ]]; then
+if ! wget -O bedrock-server.zip "$LATEST_URL"; then
   echo "ERROR: Download failed. Check your internet connection."
   exit 1
 fi

--- a/setup_minecraft.sh
+++ b/setup_minecraft.sh
@@ -18,12 +18,12 @@ fi
 
 # Set up server directory
 sudo mkdir -p /opt/minecraft
-sudo chown $(whoami):$(whoami) /opt/minecraft
+sudo chown "$(whoami)":"$(whoami)" /opt/minecraft
 cd /opt/minecraft
 
 # Fetch the latest PaperMC version
 LATEST_VERSION=$(curl -s https://api.papermc.io/v2/projects/paper | jq -r '.versions | last')
-LATEST_BUILD=$(curl -s https://api.papermc.io/v2/projects/paper/versions/$LATEST_VERSION | jq -r '.builds | last')
+LATEST_BUILD=$(curl -s https://api.papermc.io/v2/projects/paper/versions/"$LATEST_VERSION" | jq -r '.builds | last')
 
 # Validate if version and build numbers were retrieved
 if [[ -z "$LATEST_VERSION" || -z "$LATEST_BUILD" ]]; then

--- a/setup_minecraft.sh
+++ b/setup_minecraft.sh
@@ -4,7 +4,7 @@
 # Tested on Debian 11/12 and Ubuntu 24.04
 # Author: TimInTech
 
-set -e  # Exit script on error
+set -euo pipefail  # Exit script on error, undefined variable, or failed pipeline
 
 # Install required dependencies
 sudo apt update && sudo apt upgrade -y

--- a/setup_minecraft_lxc.sh
+++ b/setup_minecraft_lxc.sh
@@ -15,11 +15,11 @@ if ! apt install -y openjdk-21-jre-headless; then
 fi
 
 # Create the Minecraft server directory
-mkdir -p /opt/minecraft && cd /opt/minecraft
+mkdir -p /opt/minecraft && cd /opt/minecraft || exit
 
 # Fetch the latest PaperMC version
 LATEST_VERSION=$(curl -s https://api.papermc.io/v2/projects/paper | jq -r '.versions | last')
-LATEST_BUILD=$(curl -s https://api.papermc.io/v2/projects/paper/versions/$LATEST_VERSION | jq -r '.builds | last')
+LATEST_BUILD=$(curl -s https://api.papermc.io/v2/projects/paper/versions/"$LATEST_VERSION" | jq -r '.builds | last')
 
 # Validate if the version and build exist
 if [[ -z "$LATEST_VERSION" || -z "$LATEST_BUILD" ]]; then

--- a/setup_minecraft_lxc.sh
+++ b/setup_minecraft_lxc.sh
@@ -4,6 +4,9 @@
 # Tested on Debian 11/12 and Ubuntu 24.04
 # Author: TimInTech
 
+
+set -euo pipefail
+
 # Update package lists and install required dependencies
 apt update && apt upgrade -y
 apt install -y screen wget curl jq unzip

--- a/update.sh
+++ b/update.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 
+set -euo pipefail
+
 cd /opt/minecraft || exit 1
 
 LATEST_VERSION=$(curl -s https://api.papermc.io/v2/projects/paper | jq -r '.versions | last')
-LATEST_BUILD=$(curl -s https://api.papermc.io/v2/projects/paper/versions/$LATEST_VERSION | jq -r '.builds | last')
+LATEST_BUILD=$(curl -s https://api.papermc.io/v2/projects/paper/versions/"$LATEST_VERSION" | jq -r '.builds | last')
 
 wget -O server.jar "https://api.papermc.io/v2/projects/paper/versions/$LATEST_VERSION/builds/$LATEST_BUILD/downloads/paper-$LATEST_VERSION-$LATEST_BUILD.jar"
 


### PR DESCRIPTION
## Summary
- follow shellcheck recommendations for quoting and command failure checks
- exit on directory change failure
- add `.gitattributes` for consistent text handling

## Testing
- `shellcheck setup_minecraft.sh setup_minecraft_lxc.sh setup_bedrock.sh bedrock_helper.sh`


------
https://chatgpt.com/codex/tasks/task_e_68857233d254833388393699141f0377

## Zusammenfassung von Sourcery

Wende ShellCheck-Empfehlungen an, indem Variablen in Anführungszeichen gesetzt, Fehlerprüfungen optimiert, das Beenden bei fehlgeschlagenen Verzeichniswechseln erzwungen und eine .gitattributes-Datei für eine konsistente Textverarbeitung hinzugefügt wird.

Verbesserungen:
- Befehlssubstitutionen und Variablenerweiterungen in Shell-Skripten in Anführungszeichen setzen, um Worttrennung zu verhindern.
- Manuelle Exit-Status-Prüfungen durch "if !"-Konstrukte für Download-Befehle ersetzen.
- "|| exit" zu Verzeichniswechsel-Befehlen hinzufügen, um sicherzustellen, dass Skripte bei fehlgeschlagenen `cd`-Befehlen anhalten.

Aufräumarbeiten:
- .gitattributes hinzufügen, um eine konsistente Textverarbeitung über verschiedene Plattformen hinweg zu erzwingen.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Apply ShellCheck recommendations by quoting variables, streamlining error checks, enforcing directory change failure exits, and add a .gitattributes file for consistent text handling.

Enhancements:
- Quote command substitutions and variable expansions in shell scripts to prevent word-splitting.
- Replace manual exit-status checks with "if !" constructs for download commands.
- Add "|| exit" to directory change commands to ensure scripts halt on cd failures.

Chores:
- Add .gitattributes to enforce consistent text handling across platforms.

</details>