### PR TITLE
fix: use .versions | keys | last for deterministic latest MC version

### DIFF
--- a/setup_minecraft_lxc.sh
+++ b/setup_minecraft_lxc.sh
@@ -45,7 +45,7 @@ fi
 # ── Download latest stable PaperMC via Fill v3 API ──
 FILL_API="https://fill.papermc.io/v3/projects/paper"
 
-LATEST_VERSION=$(curl -fsSL -H "User-Agent: ${USER_AGENT}" "${FILL_API}" | jq -r '.versions | last')
+LATEST_VERSION=$(curl -fsSL -H "User-Agent: ${USER_AGENT}" "${FILL_API}" | jq -r '.versions | keys | last')
 echo "Latest Minecraft version: ${LATEST_VERSION}"
 
 BUILDS_JSON=$(curl -fsSL -H "User-Agent: ${USER_AGENT}" "${FILL_API}/versions/${LATEST_VERSION}/builds")


### PR DESCRIPTION
The Fill v3 API returns .versions as an object (keys = MC version strings), not an array. Using `keys | last` yields the lexicographically highest (= newest) version reliably. Fixes broken `.versions | last` (was null on object input) and the non-deterministic `keys_unsorted[0]` variant.

# Pull Request – Simulation Only

## Summary

Describe what this PR changes (scripts, docs). No commands are executed in this workspace.

## Checklist

- [ ] No commands executed locally; all steps are simulated/explained only.
- [ ] Changes are limited to scripts and/or documentation.
- [ ] `SIMULATION.md` updated to reflect behavior and risks.
- [ ] If adding a new script or option, included example usage commands (chmod +x; ./script; screen -r ...).
- [ ] Security considerations addressed (least-privilege user, ports, backups).

## Testing (Simulation)

Explain expected side effects if run on a proper host (files created, services started, ports opened). Include rollback/cleanup notes.
